### PR TITLE
Fix requirements to drop invalid apturl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ alembic==1.16.2
 annotated-types==0.7.0
 antlr4-python3-runtime==4.9.3
 appdirs==1.4.4
-apturl==0.5.2
 async-timeout==5.0.1
 attrs==25.3.0
 autogluon==1.3.1


### PR DESCRIPTION
## Summary
- remove `apturl` from `requirements.txt` because no package is available on PyPI

## Testing
- `grep -n "apturl" -n requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_686c854ef9408325ab876963ea6f7c5d